### PR TITLE
Add support for Django 5.x

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -35,6 +35,9 @@ jobs:
         - dj-version: '5.0.*'
           python-version: 3.9
           drf-version: '3.13.*'
+        - dj-version: '5.1.*'
+          python-version: 3.9
+          drf-version: '3.13.*'
 
     services:
       postgres:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,9 +34,11 @@ jobs:
           drf-version: '3.13.*'
         - dj-version: '5.0.*'
           python-version: 3.9
+        - dj-version: '5.0.*'
           drf-version: '3.13.*'
         - dj-version: '5.1.*'
           python-version: 3.9
+        - dj-version: '5.0.*'
           drf-version: '3.13.*'
 
     services:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.9, "3.10", "3.11"]
-        dj-version: ["3.0.*", "3.1.*", "3.2.*", "4.0.*", "4.1.*", "4.2.*"]
+        dj-version: ["3.0.*", "3.1.*", "3.2.*", "4.0.*", "4.1.*", "4.2.*", "5.0.*", "5.1.*"]
         drf-version: ["3.11.*", "3.12.*", "3.13.*", "3.14.*"]
         exclude:
         - dj-version: '4.0.*'
@@ -31,6 +31,9 @@ jobs:
         - dj-version: '4.2.*'
           drf-version: '3.12.*'
         - dj-version: '4.2.*'
+          drf-version: '3.13.*'
+        - dj-version: '5.0.*'
+          python-version: 3.9
           drf-version: '3.13.*'
 
     services:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,11 +34,19 @@ jobs:
           drf-version: '3.13.*'
         - dj-version: '5.0.*'
           python-version: 3.9
-        - dj-version: '5.0.*'
-          drf-version: '3.13.*'
         - dj-version: '5.1.*'
           python-version: 3.9
         - dj-version: '5.0.*'
+          drf-version: '3.11.*'
+        - dj-version: '5.0.*'
+          drf-version: '3.12.*'
+        - dj-version: '5.0.*'
+          drf-version: '3.13.*'
+        - dj-version: '5.1.*'
+          drf-version: '3.11.*'
+        - dj-version: '5.1.*'
+          drf-version: '3.12.*'
+        - dj-version: '5.1.*'
           drf-version: '3.13.*'
 
     services:

--- a/dynamic_rest/__init__.py
+++ b/dynamic_rest/__init__.py
@@ -8,5 +8,5 @@ DREST offers the following features on top of the standard DRF kit:
 - Directory panel for the browsable API
 - Optimizations
 """
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 default_app_config = "dynamic_rest.apps.DynamicRestConfig"

--- a/install_requires.txt
+++ b/install_requires.txt
@@ -1,4 +1,4 @@
-Django>=3.2,<4.3
+Django>=3.2,<5.2
 djangorestframework>=3.11.2,<3.15
 inflection>=0.5.0
 requests

--- a/requirements.benchmark.txt
+++ b/requirements.benchmark.txt
@@ -1,6 +1,6 @@
 django-environ==0.11.2
 django-debug-toolbar==1.7
-Django>=3.2,<4.3
+Django>=3.2,<5.2
 djangorestframework>=3.11.2,<3.15
 flake8>=3.0
 psycopg2-binary==2.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ tox-pyenv==1.1.0
 tox==4.11.3
 twine==4.0.2
 inflection==0.5.1
-Django>=3.2,<4.3
+Django>=3.2,<5.2
 djangorestframework>=3.11.2,<3.15
 orjson>=3.9.7
 black==23.9.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 NAME = "dynamic-rest-bse"
 DESCRIPTION = "Dynamic API support to Django REST Framework. Forked..."
 URL = "http://github.com/BillSchumacher/dynamic-rest"
-VERSION = "2.4.3"
+VERSION = "2.5.0"
 SCRIPTS = ["manage.py"]
 
 with open("install_requires.txt", encoding="utf-8") as fp:

--- a/tox.ini
+++ b/tox.ini
@@ -4,19 +4,19 @@ addopts=--tb=short
 [tox]
 envlist =
        py310-lint,
-       {py37,py38,py39,py310,py311}-django{22,31,32,40,41,42}-drf{311,312,313,314},
+       {py310,py311}-django{32,40,41,42,50,51}-drf{311,312,313,314},
 
 [testenv]
 commands = ./runtests.py --fast {posargs} --coverage -rw
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-        django22: Django>=2.2,<2.3
-        django31: Django>=3.1,<3.2
         django32: Django>=3.2,<3.3
         django40: Django>=4.0,<4.1
         django41: Django>=4.1,<4.2
         django42: Django>=4.2,<4.3
+        django50: Django>=5.0,<5.1
+        django51: Django>=5.1,<5.2
         drf311: djangorestframework>=3.11.2,<3.12
         drf312: djangorestframework>=3.12,<3.13
         drf313: djangorestframework>=3.13,<3.14


### PR DESCRIPTION
## Summary by Sourcery

Add support for Django 5.x by updating the testing matrix and CI configuration to include Django 5.0 and 5.1. Update the package version to 2.5.0.

New Features:
- Add support for Django 5.0 and 5.1 in the testing matrix.

CI:
- Update GitHub Actions workflow to include Django 5.0 and 5.1 in the test matrix.